### PR TITLE
this commit remove the gossip NodeAddr filter when update nodeDescs c…

### DIFF
--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -429,10 +429,15 @@ func (g *Gossip) updateNodeAddress(_ string, content roachpb.Value) {
 	}()
 
 	// Skip if the node has already been seen or it's our own address.
-	if _, ok := g.nodeDescs[desc.NodeID]; ok || desc.Address == g.is.NodeAddr {
+	if _, ok := g.nodeDescs[desc.NodeID]; ok {
 		return
 	}
 	g.nodeDescs[desc.NodeID] = &desc
+
+	// Skip if it's our own address.
+	if desc.Address == g.is.NodeAddr {
+		return
+	}
 
 	// Add this new node address (if it's not already there) to our list
 	// of resolvers so we can keep connecting to gossip if the original


### PR DESCRIPTION
This branch remove the gossip NodeAddr filter when update nodeDescs cache,so that its own nodeDesc could be added into nodeDescs cache.
Because its own nodeDesc is used frequently,so adding it to the nodeDescs cache can promote the performance(at least my test shows promotion).
Of course, I still add the filter before maybeAddResolver and maybeAddBootstrapAddress in the updateNodeAddress method.